### PR TITLE
Feat: Mutfak ekranı ile açık siparişler listeleniyor

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import OrderPage from './pages/OrderPage';
 import TableInputPage from './pages/TableInputPage';
+import KitchenPage from './pages/KitchenPage';
 
 function App() {
   return (
@@ -9,6 +10,8 @@ function App() {
       <Routes>
         <Route path="/start/:tenantCode" element={<TableInputPage />} />
         <Route path="/order/:tenantCode/:tableId" element={<OrderPage />} />
+        <Route path="/kitchen/:tenantCode" element={<KitchenPage />} />
+        <Route path="/" element={<h1>Welcome to the Restaurant App</h1>} />
       </Routes>
     </Router>
   );

--- a/frontend/src/pages/KitchenPage.jsx
+++ b/frontend/src/pages/KitchenPage.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+function KitchenPage() {
+  const { tenantCode } = useParams();
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    const fetchOrders = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/kitchen/${tenantCode}/orders`);
+        const data = await res.json();
+        setOrders(data);
+      } catch (err) {
+        console.error("Siparişler alınamadı:", err);
+      }
+    };
+
+    fetchOrders();
+  }, [tenantCode]);
+
+  return (
+    <div>
+      <h2>Mutfak Ekranı</h2>
+      {orders.map(order => (
+        <div key={order.order_id} style={{ border: '1px solid #ccc', marginBottom: '10px', padding: '10px' }}>
+          <h3>Masa: {order.name || order.table_id}</h3>
+          <p><strong>Sipariş No:</strong> {order.order_id}</p>
+          <p><strong>Oluşturulma:</strong> {new Date(order.created_at).toLocaleTimeString()}</p>
+          <ul>
+            {order.items.map(item => (
+              <li key={item.menu_item_id}>
+                {item.name} x {item.quantity}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default KitchenPage;


### PR DESCRIPTION
### Yapılanlar
- Yeni sayfa: `KitchenPage.jsx`
- API: `/kitchen/orders/:tenant` çağrısı ile açık siparişler alınıyor
- Masa adı, sipariş zamanı ve ürün listesi gösteriliyor

### Test
- URL: `/kitchen/RestaurantA/orders`
- Backend açık sipariş döndürüyor
- UI’da listeleme başarılı

### İlgili Issue
Closes #32
