### PR TITLE
Feat: Mutfak ekranına “Hazırlandı” butonu eklendi (#42)

### DIFF
--- a/frontend/src/pages/KitchenPage.jsx
+++ b/frontend/src/pages/KitchenPage.jsx
@@ -5,28 +5,53 @@ function KitchenPage() {
   const { tenantCode } = useParams();
   const [orders, setOrders] = useState([]);
 
-  useEffect(() => {
-    const fetchOrders = async () => {
-      try {
-        const res = await fetch(`/api/kitchen/${tenantCode}/orders`);
-        const data = await res.json();
-        setOrders(data);
-      } catch (err) {
-        console.error("Siparişler alınamadı:", err);
-      }
-    };
+  // fetchOrders fonksiyonunu en üste taşı
+  const fetchOrders = async () => {
+    try {
+      const res = await fetch(`/api/kitchen/${tenantCode}/orders`);
+      const data = await res.json();
+      setOrders(data);
+    } catch (err) {
+      console.error("Siparişler alınamadı:", err);
+    }
+  };
 
+  useEffect(() => {
     fetchOrders();
   }, [tenantCode]);
+
+  const markAsReady = async (orderId) => {
+    try {
+      const res = await fetch(
+        `/api/kitchen/${tenantCode}/orders/${orderId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'done' }),
+        }
+      );
+      if (!res.ok) throw new Error('Durum güncelleme başarısız');
+      fetchOrders(); // listeyi yenile
+    } catch (err) {
+      console.error(err);
+      alert('Durum güncellenemedi');
+    }
+  };
 
   return (
     <div>
       <h2>Mutfak Ekranı</h2>
       {orders.map(order => (
-        <div key={order.order_id} style={{ border: '1px solid #ccc', marginBottom: '10px', padding: '10px' }}>
+        <div
+          key={order.order_id}
+          style={{ border: '1px solid #ccc', marginBottom: '10px', padding: '10px' }}
+        >
           <h3>Masa: {order.name || order.table_id}</h3>
           <p><strong>Sipariş No:</strong> {order.order_id}</p>
-          <p><strong>Oluşturulma:</strong> {new Date(order.created_at).toLocaleTimeString()}</p>
+          <p>
+            <strong>Oluşturulma:</strong>{' '}
+            {new Date(order.created_at).toLocaleTimeString()}
+          </p>
           <ul>
             {order.items.map(item => (
               <li key={item.menu_item_id}>
@@ -34,6 +59,11 @@ function KitchenPage() {
               </li>
             ))}
           </ul>
+          {order.status !== 'done' && (
+            <button onClick={() => markAsReady(order.order_id)}>
+              Hazırlandı
+            </button>
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
### Yapılanlar
- `KitchenPage.jsx`’e “Hazırlandı” butonu eklendi
- Butona tıklanınca `PATCH /api/kitchen/:tenant/orders/:orderId` endpoint’i çağrılıyor
- Başarıyla güncellendikten sonra liste yenileniyor

### Test
1. `/kitchen/RestaurantA/orders` sayfasını açın
2. Açık bir sipariş için “Hazırlandı” butonuna tıklayın
3. Sipariş backend’de `done` durumuna güncellenmeli ve UI otomatik yenilenmeli

Closes #42
